### PR TITLE
Example calls NUTS for Enrollment UCs

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,26 @@
+
+services:
+  nutsnode-hospital:
+    image: nutsfoundation/nuts-node:6.0.0-beta.11
+    ports:
+      - "8080:8080" # port for public access (DIDs)
+      - "8081:8081" # port exposed for loading test data (create DIDs and VCs, requesting access token)
+    environment:
+      - NUTS_VERBOSITY=debug
+      - NUTS_STRICTMODE=false
+      - NUTS_HTTP_INTERNAL_ADDRESS=:8081
+      - NUTS_AUTH_CONTRACTVALIDATORS=dummy
+      - NUTS_URL=${HOSPITAL_EXTERNAL_API}
+      - NUTS_VDR_DIDMETHODS=web
+  nutsnode-cps:
+    image: nutsfoundation/nuts-node:6.0.0-beta.11
+    ports:
+      - "8180:8080" # port for public access (DIDs)
+      - "8181:8081" # port exposed for loading test data (create DIDs and VCs, requesting access token)
+    environment:
+      - NUTS_VERBOSITY=debug
+      - NUTS_STRICTMODE=false
+      - NUTS_HTTP_INTERNAL_ADDRESS=:8081
+      - NUTS_AUTH_CONTRACTVALIDATORS=dummy
+      - NUTS_URL=${CPS_EXTERNAL_API}
+      - NUTS_VDR_DIDMETHODS=web

--- a/input/images/cUrl-POST-Nuts-hospitalx-create-did-vc.sh
+++ b/input/images/cUrl-POST-Nuts-hospitalx-create-did-vc.sh
@@ -1,0 +1,67 @@
+export NAME="hospital_x"
+export URA="124453423"
+export CITY="Amsterdam"
+export HOSPITAL_INTERNAL_API="http://localhost:8081"
+export CPS_INTERNAL_API="http://localhost:8181"
+
+
+
+echo "Create $NAME DID"
+HOSPITAL_DID_DOC=$(curl --location "${HOSPITAL_INTERNAL_API}/internal/vdr/v2/subject" \
+--header 'Content-Type: application/json' \
+--header 'Accept: application/json' \
+--data "{
+  \"subject\": \"${NAME}\"
+}")
+echo "$HOSPITAL_DID_DOC"
+HOSPITAL_DID=$(echo "$HOSPITAL_DID_DOC" | jq -r .documents[0].id)
+echo "$HOSPITAL_DID"
+
+echo "Create CPS DID"
+CPS_DID_DOC=$(curl --location "${CPS_INTERNAL_API}/internal/vdr/v2/subject" \
+--header 'Content-Type: application/json' \
+--header 'Accept: application/json' \
+--data "{
+  \"subject\": \"CPS\"
+}")
+echo "$CPS_DID_DOC"
+CPS_DID=$(echo "$CPS_DID_DOC" | jq -r .documents[0].id)
+echo "$CPS_DID"
+
+VC_DOC=$(curl --location "${CPS_INTERNAL_API}/internal/vcr/v2/issuer/vc" \
+--header 'Content-Type: application/json' \
+--header 'Accept: application/json' \
+--data-raw "{
+    \"@context\": [
+      \"https://www.w3.org/2018/credentials/v1\",
+      \"https://nuts.nl/credentials/2024\"
+    ],
+    \"type\": \"NutsUraCredential\",
+    \"issuer\": \"${CPS_DID}\",
+    \"credentialSubject\": {
+      \"id\": \"${HOSPITAL_DID}\",
+      \"organization\": {
+        \"ura\": \"${URA}\",
+        \"name\": \"${NAME}\",
+        \"city\": \"${CITY}\"
+      }
+    },
+    \"withStatusList2021Revocation\": false
+  }")
+
+echo "$VC_DOC"
+
+
+curl --location "$HOSPITAL_INTERNAL_API/internal/vcr/v2/holder/$HOSPITAL_DID/vc" \
+  --header 'Content-Type: application/json' \
+  --data "$VC_DOC"
+
+curl --location "$HOSPITAL_INTERNAL_API/internal/vcr/v2/holder/did:web:d996-195-240-138-159.ngrok-free.app:iam:221ab978-ecea-48f8-b146-3450d8e6f386/vc" \
+--header 'Accept: application/json'
+
+curl --location "$HOSPITAL_INTERNAL_API/internal/auth/v2/$HOSPITAL_DID/request-service-access-token" \
+  --header 'Content-Type: application/json' \
+--data-raw "{
+    \"verifier\": \"${CPS_DID}\",
+    \"scope\": \"scp_cpc\"
+  }"

--- a/input/images/docker-compose-nuts-nodes.sh
+++ b/input/images/docker-compose-nuts-nodes.sh
@@ -1,0 +1,9 @@
+# Please run the following command and replace the HOSPITAL_EXTERNAL_API with the value of the external URL created by ngrok
+# ngrok http 8080
+# Please run the following command and replace the CPS_EXTERNAL_API with the value of the external URL created by ngrok
+# ngrok http 8980
+
+export HOSPITAL_EXTERNAL_API="https://....ngrok-free.app"
+export CPS_EXTERNAL_API="https://....ngrok-free.app"
+
+docker compose -f docker-compose-nuts-nodes.yaml up

--- a/input/images/docker-compose-nuts-nodes.yaml
+++ b/input/images/docker-compose-nuts-nodes.yaml
@@ -1,0 +1,26 @@
+
+services:
+  nutsnode-hospital:
+    image: nutsfoundation/nuts-node:6.0.0-beta.11
+    ports:
+      - "8080:8080" # port for public access (DIDs)
+      - "8081:8081" # port exposed for loading test data (create DIDs and VCs, requesting access token)
+    environment:
+      - NUTS_VERBOSITY=debug
+      - NUTS_STRICTMODE=false
+      - NUTS_HTTP_INTERNAL_ADDRESS=:8081
+      - NUTS_AUTH_CONTRACTVALIDATORS=dummy
+      - NUTS_URL=${HOSPITAL_EXTERNAL_API}
+      - NUTS_VDR_DIDMETHODS=web
+  nutsnode-cps:
+    image: nutsfoundation/nuts-node:6.0.0-beta.11
+    ports:
+      - "8180:8080" # port for public access (DIDs)
+      - "8181:8081" # port exposed for loading test data (create DIDs and VCs, requesting access token)
+    environment:
+      - NUTS_VERBOSITY=debug
+      - NUTS_STRICTMODE=false
+      - NUTS_HTTP_INTERNAL_ADDRESS=:8081
+      - NUTS_AUTH_CONTRACTVALIDATORS=dummy
+      - NUTS_URL=${CPS_EXTERNAL_API}
+      - NUTS_VDR_DIDMETHODS=web

--- a/input/pagecontent/usecase-enrollment.md
+++ b/input/pagecontent/usecase-enrollment.md
@@ -37,6 +37,10 @@ Caroline monitors the (shared) request in the EHR and sees that a few days later
 
 ### Transactions
 
+#### Preparation: did and VCs
+1. Please read the file and execute the ngrok commands first: [docker-compose-nuts-nodes.sh](docker-compose-nuts-nodes.sh)
+2. [cUrl-POST-Nuts-hospitalx-create-did-vc](cUrl-POST-Nuts-hospitalx-create-did-vc.sh)
+
 #### Preparation: populating existing data at Hospital X and MedicalServiceCentre 
 1. [cUrl POST Bundle-hospitalx-bundle-01 to cpc1-base-url](cUrl-POST-Bundle-hospitalx-bundle-01-to-cpc1-base-url.txt), payload: [Bundle-hospitalx-bundle-01](Bundle-hospitalx-bundle-01.json)
 1. [cUrl POST Bundle-msc-bundle-01 to cpc2-base-url](cUrl-POST-Bundle-msc-bundle-01-to-cpc2-base-url.txt), payload: [Bundle-msc-bundle-01](Bundle-msc-bundle-01.json)


### PR DESCRIPTION
Added scripts to set up Nuts node environments and create DIDs and VCs for Hospital X and CPS entities. Updated usecase-enrollment.md with instructions to run the new scripts for setting up DIDs and VCs.